### PR TITLE
Add support for logging via the log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ authors = ["Tupshin Harper <tupshin@tupshin.com>", "Keith Wansbrough <Keith.Wans
 edition = "2018"
 
 [dependencies]
-slog = "2"
+slog = { version = "2", optional = true }
+log = { version = "0.4.17", optional = true }
 cassandra-cpp-sys = "1.1.0"
 uuid = "1.0"
 error-chain = "0.12"
@@ -23,7 +24,8 @@ libc = "0.2"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros", "test-util"] }
 futures = "0.3.1"
+logtest = "2.0.0"
 
 [features]
-default = []
+default = ["slog", "log"]
 early_access_min_tls_version = ["cassandra-cpp-sys/early_access_min_tls_version"]

--- a/src/cassandra/log.rs
+++ b/src/cassandra/log.rs
@@ -91,6 +91,17 @@ unsafe extern "C" fn slog_callback(log: *const CassLogMessage, data: *mut raw::c
     };
 }
 
+#[doc(hidden)]
+#[cfg(feature = "slog")]
+/// Set or unset a logger to receive all Cassandra driver logs.
+pub fn set_logger(logger: Option<slog::Logger>) {
+    if let Some(logger) = logger {
+        set_slog_logger(logger);
+    } else {
+        unset_logger();
+    }
+}
+
 #[cfg(feature = "slog")]
 /// Set a slog logger to receive all Cassandra driver logs.
 pub fn set_slog_logger(logger: slog::Logger) {
@@ -136,6 +147,7 @@ unsafe extern "C" fn log_callback(log: *const CassLogMessage, _data: *mut raw::c
     );
 }
 
+/// Extract the module name from a cpp function definition
 fn function_definition_to_module_name(definition: &str) -> Option<&str> {
     // definition strings look like:
     // void datastax::internal::core::ControlConnection::handle_refresh_keyspace(datastax::internal::core::RefreshKeyspaceCallback*))

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -61,6 +61,7 @@ use crate::cassandra_sys::cass_statement_set_request_timeout;
 use crate::cassandra_sys::cass_statement_set_retry_policy;
 use crate::cassandra_sys::cass_statement_set_serial_consistency;
 use crate::cassandra_sys::cass_statement_set_timestamp;
+use crate::cassandra_sys::cass_statement_set_tracing;
 use crate::cassandra_sys::cass_true;
 use crate::cassandra_sys::CassStatement as _Statement;
 use crate::cassandra_sys::CASS_UINT64_MAX;
@@ -439,6 +440,14 @@ impl Statement {
     /// Sets the statement's custom payload.
     pub fn set_custom_payload(&mut self, payload: CustomPayload) -> Result<&mut Self> {
         unsafe { cass_statement_set_custom_payload(self.0, payload.inner()).to_result(self) }
+    }
+
+    /// Sets the statement's tracing flag.
+    pub fn set_tracing(&mut self, value: bool) -> Result<&mut Self> {
+        unsafe {
+            cass_statement_set_tracing(self.0, if value { cass_true } else { cass_false })
+                .to_result(self)
+        }
     }
 
     /// Binds null to a query or bound statement at the specified index.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 // `error_chain!` can recurse deeply
 #![recursion_limit = "1024"]
 
+#[cfg(feature = "slog")]
 #[macro_use]
 extern crate slog;
 #[macro_use]
@@ -30,7 +31,11 @@ pub use crate::cassandra::iterator::{
     AggregateIterator, ColumnIterator, FieldIterator, FunctionIterator, KeyspaceIterator,
     MapIterator, SetIterator, TableIterator, UserTypeIterator,
 };
-pub use crate::cassandra::log::{set_level, set_logger, LogLevel};
+#[cfg(feature = "log")]
+pub use crate::cassandra::log::set_log_logger;
+#[cfg(feature = "slog")]
+pub use crate::cassandra::log::set_slog_logger;
+pub use crate::cassandra::log::{set_level, LogLevel};
 pub use crate::cassandra::policy::retry::RetryPolicy;
 pub use crate::cassandra::prepared::PreparedStatement;
 pub use crate::cassandra::result::CassResult;


### PR DESCRIPTION
My goal was actually to hook cassandra-rs up to tracing rather than the log crate.
However doing that proved to be incredibly complex.
tracing does a lot of crazy compile time magic to make it go fast, so converting runtime log data provided by the cpp data to tracing's format is really tricky, if you want to see what I mean just take a look at the implementations of tracing-slog or tracing-log.
I also tried using the tracing-slog crate with cassandra-rs's slog support but that maps very poorly to tracing: https://docs.rs/tracing-slog/latest/tracing_slog/
On the other hand the tracing log crate https://docs.rs/tracing-log/latest/tracing_log/ works really well, so the solution I settled for was implementing log for cassandra-rs and using tracing-log to convert that to tracing.

This also has extra benefits:
* this project is the only dependency pulling in slog for me, so making slog optional removes it from my project
* Better support for log users which appears to be more popular than slog?

In order to support multiple logger implementations, the API is changed to:
```rust
// Enabled by slog feature
set_slog_logger(..)
// Enabled by log feature
set_log_logger()
unset_logger()
```

I also noticed a bug in the slog implementation where we used the file instead of the function so I fixed that.

Some logs coming through in tracing on my project:
![image](https://user-images.githubusercontent.com/5120858/194791422-b2a4d45d-a946-4a79-b43f-aaf537f8fdc4.png)
